### PR TITLE
Avoid TypeError exception when self.children is None

### DIFF
--- a/src/antlr4/ParserRuleContext.py
+++ b/src/antlr4/ParserRuleContext.py
@@ -174,7 +174,7 @@ class ParserRuleContext(RuleContext):
         return contexts
 
     def getChildCount(self):
-        return len(self.children)
+        return len(self.children) if self.children else 0
 
     def getSourceInterval(self):
         if self.start is None or self.stop is None:


### PR DESCRIPTION
I'm just getting started with antlr4 on python and stumbled on this issue. Java run-time also test for null.