### PR TITLE
Make compatible with Python 3.2

### DIFF
--- a/src/antlr4/FileStream.py
+++ b/src/antlr4/FileStream.py
@@ -53,5 +53,5 @@ class FileStream(InputStream):
 class TestFileStream(unittest.TestCase):
 
     def testStream(self):
-        stream = FileStream("FileStream.py")
+        stream = FileStream(__file__)
         self.assertTrue(stream.size>0)

--- a/src/antlr4/IntervalSet.py
+++ b/src/antlr4/IntervalSet.py
@@ -154,16 +154,16 @@ class IntervalSet(object):
             return "{}"
         with StringIO() as buf:
             if len(self)>1:
-                buf.write(u"{")
+                buf.write("{")
             first = True
             for i in self.intervals:
                 for j in i:
                     if not first:
-                        buf.write(u", ")
+                        buf.write(", ")
                     buf.write(self.elementName(literalNames, symbolicNames, j))
                     first = False
             if len(self)>1:
-                buf.write(u"}")
+                buf.write("}")
             return buf.getvalue()
 
     def elementName(self, literalNames:list, symbolicNames:list, a:int):

--- a/src/antlr4/IntervalSet.py
+++ b/src/antlr4/IntervalSet.py
@@ -2,6 +2,26 @@ from io import StringIO
 import unittest
 from antlr4.Token import Token
 
+try:
+    range.start
+
+    Interval = range
+except AttributeError:
+    class Interval(object):
+        def __init__(self, start, stop):
+            self.start = start
+            self.stop = stop
+            self.range = range(start, stop)
+    
+        def __contains__(self, item):
+            return item in self.range
+        
+        def __len__(self):
+            return self.stop - self.start
+    
+        def __iter__(self):
+            return iter(self.range)
+
 IntervalSet = None
 
 class IntervalSet(object):
@@ -26,9 +46,9 @@ class IntervalSet(object):
         return Token.INVALID_TYPE
 
     def addOne(self, v:int):
-        self.addRange(range(v, v+1))
+        self.addRange(Interval(v, v+1))
 
-    def addRange(self, v:range):
+    def addRange(self, v:Interval):
         if self.intervals is None:
             self.intervals = list()
             self.intervals.append(v)
@@ -42,11 +62,11 @@ class IntervalSet(object):
                     return
                 # contiguous range -> adjust
                 elif v.stop==i.start:
-                    self.intervals[k] = range(v.start, i.stop)
+                    self.intervals[k] = Interval(v.start, i.stop)
                     return
                 # overlapping range -> adjust and reduce
                 elif v.start<=i.stop:
-                    self.intervals[k] = range(min(i.start,v.start), max(i.stop,v.stop))
+                    self.intervals[k] = Interval(min(i.start,v.start), max(i.stop,v.stop))
                     self.reduce(k)
                     return
                 k += 1
@@ -69,12 +89,12 @@ class IntervalSet(object):
                 self.intervals.pop(k+1)
                 self.reduce(k)
             elif l.stop >= r.start:
-                self.intervals[k] = range(l.start, r.stop)
+                self.intervals[k] = Interval(l.start, r.stop)
                 self.intervals.pop(k+1)
 
     def complement(self, start, stop):
         result = IntervalSet()
-        result.addRange(range(start,stop+1))
+        result.addRange(Interval(start,stop+1))
         for i in self.intervals:
             result.removeRange(i)
         return result
@@ -105,8 +125,8 @@ class IntervalSet(object):
                     return
                 # check for including range, split it
                 elif v.start>i.start and v.stop<i.stop:
-                    self.intervals[k] = range(i.start, v.start)
-                    x = range(v.stop, i.stop)
+                    self.intervals[k] = Interval(i.start, v.start)
+                    x = Interval(v.stop, i.stop)
                     self.intervals.insert(k, x)
                     return
                 # check for included range, remove it
@@ -115,10 +135,10 @@ class IntervalSet(object):
                     k = k - 1 # need another pass
                 # check for lower boundary
                 elif v.start<i.stop:
-                    self.intervals[k] = range(i.start, v.start)
+                    self.intervals[k] = Interval(i.start, v.start)
                 # check for upper boundary
                 elif v.stop<i.stop:
-                    self.intervals[k] = range(v.stop, i.stop)
+                    self.intervals[k] = Interval(v.stop, i.stop)
                 k += 1
 
     def removeOne(self, v):
@@ -134,15 +154,15 @@ class IntervalSet(object):
                     return
                 # check for lower boundary
                 elif v==i.start:
-                    self.intervals[k] = range(i.start+1, i.stop)
+                    self.intervals[k] = Interval(i.start+1, i.stop)
                     return
                 # check for upper boundary
                 elif v==i.stop-1:
-                    self.intervals[k] = range(i.start, i.stop-1)
+                    self.intervals[k] = Interval(i.start, i.stop-1)
                     return
                 # split existing range
                 elif v<i.stop-1:
-                    x = range(i.start, v)
+                    x = Interval(i.start, v)
                     i.start = v + 1
                     self.intervals.insert(k, x)
                     return
@@ -203,15 +223,15 @@ class TestIntervalSet(unittest.TestCase):
 
     def testRange(self):
         s = IntervalSet()
-        s.addRange(range(30,41))
+        s.addRange(Interval(30,41))
         self.assertTrue(30 in s)
         self.assertTrue(40 in s)
         self.assertTrue(35 in s)
 
     def testDistinct1(self):
         s = IntervalSet()
-        s.addRange(range(30,32))
-        s.addRange(range(40,42))
+        s.addRange(Interval(30,32))
+        s.addRange(Interval(40,42))
         self.assertEquals(2,len(s.intervals))
         self.assertTrue(30 in s)
         self.assertTrue(40 in s)
@@ -219,8 +239,8 @@ class TestIntervalSet(unittest.TestCase):
 
     def testDistinct2(self):
         s = IntervalSet()
-        s.addRange(range(40,42))
-        s.addRange(range(30,32))
+        s.addRange(Interval(40,42))
+        s.addRange(Interval(30,32))
         self.assertEquals(2,len(s.intervals))
         self.assertTrue(30 in s)
         self.assertTrue(40 in s)
@@ -228,8 +248,8 @@ class TestIntervalSet(unittest.TestCase):
 
     def testContiguous1(self):
         s = IntervalSet()
-        s.addRange(range(30,36))
-        s.addRange(range(36,41))
+        s.addRange(Interval(30,36))
+        s.addRange(Interval(36,41))
         self.assertEquals(1,len(s.intervals))
         self.assertTrue(30 in s)
         self.assertTrue(40 in s)
@@ -237,41 +257,41 @@ class TestIntervalSet(unittest.TestCase):
 
     def testContiguous2(self):
         s = IntervalSet()
-        s.addRange(range(36,41))
-        s.addRange(range(30,36))
+        s.addRange(Interval(36,41))
+        s.addRange(Interval(30,36))
         self.assertEquals(1,len(s.intervals))
         self.assertTrue(30 in s)
         self.assertTrue(40 in s)
 
     def testOverlapping1(self):
         s = IntervalSet()
-        s.addRange(range(30,40))
-        s.addRange(range(35,45))
+        s.addRange(Interval(30,40))
+        s.addRange(Interval(35,45))
         self.assertEquals(1,len(s.intervals))
         self.assertTrue(30 in s)
         self.assertTrue(44 in s)
 
     def testOverlapping2(self):
         s = IntervalSet()
-        s.addRange(range(35,45))
-        s.addRange(range(30,40))
+        s.addRange(Interval(35,45))
+        s.addRange(Interval(30,40))
         self.assertEquals(1,len(s.intervals))
         self.assertTrue(30 in s)
         self.assertTrue(44 in s)
 
     def testOverlapping3(self):
         s = IntervalSet()
-        s.addRange(range(30,32))
-        s.addRange(range(40,42))
-        s.addRange(range(50,52))
-        s.addRange(range(20,61))
+        s.addRange(Interval(30,32))
+        s.addRange(Interval(40,42))
+        s.addRange(Interval(50,52))
+        s.addRange(Interval(20,61))
         self.assertEquals(1,len(s.intervals))
         self.assertTrue(20 in s)
         self.assertTrue(60 in s)
 
     def testComplement(self):
         s = IntervalSet()
-        s.addRange(range(10,21))
+        s.addRange(Interval(10,21))
         c = s.complement(1,100)
         self.assertTrue(1 in c)
         self.assertTrue(100 in c)

--- a/src/antlr4/LL1Analyzer.py
+++ b/src/antlr4/LL1Analyzer.py
@@ -28,7 +28,7 @@
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 #  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #/
-from antlr4.IntervalSet import IntervalSet
+from antlr4.IntervalSet import IntervalSet, Interval
 from antlr4.Token import Token
 from antlr4.PredictionContext import PredictionContext, SingletonPredictionContext, PredictionContextFromRuleContext
 from antlr4.RuleContext import RuleContext
@@ -188,7 +188,7 @@ class LL1Analyzer (object):
             elif t.isEpsilon:
                 self._LOOK(t.target, stopState, ctx, look, lookBusy, calledRuleStack, seeThruPreds, addEOF)
             elif type(t) == WildcardTransition:
-                look.addRange( range(Token.MIN_USER_TOKEN_TYPE, self.atn.maxTokenType + 1) )
+                look.addRange( Interval(Token.MIN_USER_TOKEN_TYPE, self.atn.maxTokenType + 1) )
             else:
                 set = t.label
                 if set is not None:

--- a/src/antlr4/ParserInterpreter.py
+++ b/src/antlr4/ParserInterpreter.py
@@ -50,7 +50,7 @@ from antlr4.Token import Token
 from antlr4.atn.ATN import ATN
 from antlr4.atn.ATNState import StarLoopEntryState, ATNState, LoopEndState
 from antlr4.atn.ParserATNSimulator import ParserATNSimulator
-from antlr4.atn.PredictionContextCache import PredictionContextCache
+from antlr4.PredictionContext import PredictionContextCache
 from antlr4.atn.Transition import Transition
 from antlr4.error.Errors import RecognitionException, UnsupportedOperationException, FailedPredicateException
 

--- a/src/antlr4/ParserRuleContext.py
+++ b/src/antlr4/ParserRuleContext.py
@@ -132,7 +132,7 @@ class ParserRuleContext(RuleContext):
 
     def getChildren(self):
         if self.children is None:
-            return None
+            return
         for child in self.children:
             yield child
 

--- a/src/antlr4/PredictionContext.py
+++ b/src/antlr4/PredictionContext.py
@@ -238,20 +238,20 @@ class ArrayPredictionContext(PredictionContext):
         if self.isEmpty():
             return "[]"
         with StringIO() as buf:
-            buf.write(u"[")
+            buf.write("[")
             for i in range(0,len(self.returnStates)):
                 if i>0:
-                    buf.write(u", ")
+                    buf.write(", ")
                 if self.returnStates[i]==PredictionContext.EMPTY_RETURN_STATE:
-                    buf.write(u"$")
+                    buf.write("$")
                     continue
                 buf.write(self.returnStates[i])
                 if self.parents[i] is not None:
                     buf.write(' ')
                     buf.write(str(self.parents[i]))
                 else:
-                    buf.write(u"null")
-            buf.write(u"]")
+                    buf.write("null")
+            buf.write("]")
             return buf.getvalue()
 
 

--- a/src/antlr4/RuleContext.py
+++ b/src/antlr4/RuleContext.py
@@ -216,7 +216,7 @@ class RuleContext(RuleNode):
     def toString(self, ruleNames:list, stop:RuleContext)->str:
         with StringIO() as buf:
             p = self
-            buf.write(u"[")
+            buf.write("[")
             while p is not None and p is not stop:
                 if ruleNames is None:
                     if not p.isEmpty():
@@ -227,10 +227,10 @@ class RuleContext(RuleNode):
                     buf.write(ruleName)
 
                 if p.parentCtx is not None and (ruleNames is not None or not p.parentCtx.isEmpty()):
-                    buf.write(u" ")
+                    buf.write(" ")
 
                 p = p.parentCtx
 
-            buf.write(u"]")
+            buf.write("]")
             return buf.getvalue()
 

--- a/src/antlr4/Token.py
+++ b/src/antlr4/Token.py
@@ -151,13 +151,13 @@ class CommonToken(Token):
 
     def __str__(self):
         with StringIO() as buf:
-            buf.write(u"[@")
+            buf.write("[@")
             buf.write(str(self.tokenIndex))
-            buf.write(u",")
+            buf.write(",")
             buf.write(str(self.start))
-            buf.write(u":")
+            buf.write(":")
             buf.write(str(self.stop))
-            buf.write(u"='")
+            buf.write("='")
             txt = self.text
             if txt is not None:
                 txt = txt.replace("\n","\\n")
@@ -166,15 +166,15 @@ class CommonToken(Token):
             else:
                 txt = "<no text>"
             buf.write(txt)
-            buf.write(u"',<")
+            buf.write("',<")
             buf.write(str(self.type))
-            buf.write(u">")
+            buf.write(">")
             if self.channel > 0:
-                buf.write(u",channel=")
+                buf.write(",channel=")
                 buf.write(str(self.channel))
-            buf.write(u",")
+            buf.write(",")
             buf.write(str(self.line))
-            buf.write(u":")
+            buf.write(":")
             buf.write(str(self.column))
-            buf.write(u"]")
+            buf.write("]")
             return buf.getvalue()

--- a/src/antlr4/Utils.py
+++ b/src/antlr4/Utils.py
@@ -48,11 +48,11 @@ def escapeWhitespace(s:str, escapeSpaces:bool):
             if c==' ' and escapeSpaces:
                 buf.write('\u00B7')
             elif c=='\t':
-                buf.write(u"\\t")
+                buf.write("\\t")
             elif c=='\n':
-                buf.write(u"\\n")
+                buf.write("\\n")
             elif c=='\r':
-                buf.write(u"\\r")
+                buf.write("\\r")
             else:
                 buf.write(c)
         return buf.getvalue()

--- a/src/antlr4/atn/ATNConfig.py
+++ b/src/antlr4/atn/ATNConfig.py
@@ -110,17 +110,17 @@ class ATNConfig(object):
         with StringIO() as buf:
             buf.write('(')
             buf.write(str(self.state))
-            buf.write(u",")
+            buf.write(",")
             buf.write(str(self.alt))
             if self.context is not None:
-                buf.write(u",[")
+                buf.write(",[")
                 buf.write(str(self.context))
-                buf.write(u"]")
+                buf.write("]")
             if self.semanticContext is not None and self.semanticContext is not SemanticContext.NONE:
-                buf.write(u",")
+                buf.write(",")
                 buf.write(str(self.semanticContext))
             if self.reachesIntoOuterContext>0:
-                buf.write(u",up=")
+                buf.write(",up=")
                 buf.write(str(self.reachesIntoOuterContext))
             buf.write(')')
             return buf.getvalue()

--- a/src/antlr4/atn/ATNConfigSet.py
+++ b/src/antlr4/atn/ATNConfigSet.py
@@ -214,16 +214,16 @@ class ATNConfigSet(object):
         with StringIO() as buf:
             buf.write(str_list(self.configs))
             if self.hasSemanticContext:
-                buf.write(u",hasSemanticContext=")
+                buf.write(",hasSemanticContext=")
                 buf.write(str(self.hasSemanticContext))
             if self.uniqueAlt!=ATN.INVALID_ALT_NUMBER:
-                buf.write(u",uniqueAlt=")
+                buf.write(",uniqueAlt=")
                 buf.write(str(self.uniqueAlt))
             if self.conflictingAlts is not None:
-                buf.write(u",conflictingAlts=")
+                buf.write(",conflictingAlts=")
                 buf.write(str(self.conflictingAlts))
             if self.dipsIntoOuterContext:
-                buf.write(u",dipsIntoOuterContext")
+                buf.write(",dipsIntoOuterContext")
             return buf.getvalue()
 
 

--- a/src/antlr4/atn/ATNDeserializer.py
+++ b/src/antlr4/atn/ATNDeserializer.py
@@ -29,6 +29,7 @@
 #/
 from uuid import UUID
 from io import StringIO
+from antlr4.IntervalSet import Interval
 from antlr4.Token import Token
 from antlr4.atn.ATN import ATN
 from antlr4.atn.ATNType import ATNType
@@ -211,7 +212,7 @@ class ATNDeserializer (object):
             for j in range(0, n):
                 i1 = self.readInt()
                 i2 = self.readInt()
-                iset.addRange(range(i1, i2 + 1)) # range upper limit is exclusive
+                iset.addRange(Interval(i1, i2 + 1)) # range upper limit is exclusive
         return sets
 
     def readEdges(self, atn:ATN, sets:list):

--- a/src/antlr4/atn/LexerActionExecutor.py
+++ b/src/antlr4/atn/LexerActionExecutor.py
@@ -37,7 +37,7 @@
 # not cause bloating of the {@link DFA} created for the lexer.</p>
 
 
-from antlr4 import InputStream
+from antlr4.InputStream import InputStream
 from antlr4.atn.LexerAction import LexerAction, LexerIndexedCustomAction
 
 # need a forward declaration

--- a/src/antlr4/atn/SemanticContext.py
+++ b/src/antlr4/atn/SemanticContext.py
@@ -139,9 +139,9 @@ class Predicate(SemanticContext):
     def __hash__(self):
         with StringIO() as buf:
             buf.write(str(self.ruleIndex))
-            buf.write(u"/")
+            buf.write("/")
             buf.write(str(self.predIndex))
-            buf.write(u"/")
+            buf.write("/")
             buf.write(str(self.isCtxDependent))
             return hash(buf.getvalue())
 
@@ -267,7 +267,7 @@ class AND(SemanticContext):
             first = True
             for o in self.opnds:
                 if not first:
-                    buf.write(u"&&")
+                    buf.write("&&")
                 buf.write(str(o))
                 first = False
             return buf.getvalue()
@@ -352,7 +352,7 @@ class OR (SemanticContext):
             first = True
             for o in self.opnds:
                 if not first:
-                    buf.write(u"||")
+                    buf.write("||")
                 buf.write(str(o))
                 first = False
             return buf.getvalue()

--- a/src/antlr4/atn/Transition.py
+++ b/src/antlr4/atn/Transition.py
@@ -41,7 +41,7 @@
 #  the states. We'll use the term Edge for the DFA to distinguish them from
 #  ATN transitions.</p>
 #
-from antlr4.IntervalSet import IntervalSet
+from antlr4.IntervalSet import IntervalSet, Interval
 from antlr4.Token import Token
 
 # need forward declarations
@@ -148,7 +148,7 @@ class RangeTransition(Transition):
 
     def makeLabel(self):
         s = IntervalSet()
-        s.addRange(range(self.start, self.stop + 1))
+        s.addRange(Interval(self.start, self.stop + 1))
         return s
 
     def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int):
@@ -208,7 +208,7 @@ class SetTransition(Transition):
             self.label = set
         else:
             self.label = IntervalSet()
-            self.label.addRange(range(Token.INVALID_TYPE, Token.INVALID_TYPE + 1))
+            self.label.addRange(Interval(Token.INVALID_TYPE, Token.INVALID_TYPE + 1))
 
     def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int):
         return symbol in self.label

--- a/src/antlr4/dfa/DFASerializer.py
+++ b/src/antlr4/dfa/DFASerializer.py
@@ -56,9 +56,9 @@ class DFASerializer(object):
                     if t is not None and t.stateNumber != 0x7FFFFFFF:
                         buf.write(self.getStateString(s))
                         label = self.getEdgeLabel(i)
-                        buf.write(u"-")
+                        buf.write("-")
                         buf.write(label)
-                        buf.write(u"->")
+                        buf.write("->")
                         buf.write(self.getStateString(t))
                         buf.write('\n')
             output = buf.getvalue()

--- a/src/antlr4/dfa/DFAState.py
+++ b/src/antlr4/dfa/DFAState.py
@@ -139,10 +139,10 @@ class DFAState(object):
     def __str__(self):
         with StringIO() as buf:
             buf.write(str(self.stateNumber))
-            buf.write(u":")
+            buf.write(":")
             buf.write(str(self.configs))
             if self.isAcceptState:
-                buf.write(u"=>")
+                buf.write("=>")
                 if self.predicates is not None:
                     buf.write(str(self.predicates))
                 else:

--- a/src/antlr4/error/DiagnosticErrorListener.py
+++ b/src/antlr4/error/DiagnosticErrorListener.py
@@ -66,34 +66,34 @@ class DiagnosticErrorListener(ErrorListener):
             return
 
         with StringIO() as buf:
-            buf.write(u"reportAmbiguity d=")
+            buf.write("reportAmbiguity d=")
             buf.write(self.getDecisionDescription(recognizer, dfa))
-            buf.write(u": ambigAlts=")
+            buf.write(": ambigAlts=")
             buf.write(str(self.getConflictingAlts(ambigAlts, configs)))
-            buf.write(u", input='")
+            buf.write(", input='")
             buf.write(recognizer.getTokenStream().getText((startIndex, stopIndex)))
-            buf.write(u"'")
+            buf.write("'")
             recognizer.notifyErrorListeners(buf.getvalue())
 
 
     def reportAttemptingFullContext(self, recognizer:Parser, dfa:DFA, startIndex:int,
                        stopIndex:int, conflictingAlts:set, configs:ATNConfigSet):
         with StringIO() as buf:
-            buf.write(u"reportAttemptingFullContext d=")
+            buf.write("reportAttemptingFullContext d=")
             buf.write(self.getDecisionDescription(recognizer, dfa))
-            buf.write(u", input='")
+            buf.write(", input='")
             buf.write(recognizer.getTokenStream().getText((startIndex, stopIndex)))
-            buf.write(u"'")
+            buf.write("'")
             recognizer.notifyErrorListeners(buf.getvalue())
 
     def reportContextSensitivity(self, recognizer:Parser, dfa:DFA, startIndex:int,
                        stopIndex:int, prediction:int, configs:ATNConfigSet):
         with StringIO() as buf:
-            buf.write(u"reportContextSensitivity d=")
+            buf.write("reportContextSensitivity d=")
             buf.write(self.getDecisionDescription(recognizer, dfa))
-            buf.write(u", input='")
+            buf.write(", input='")
             buf.write(recognizer.getTokenStream().getText((startIndex, stopIndex)))
-            buf.write(u"'")
+            buf.write("'")
             recognizer.notifyErrorListeners(buf.getvalue())
 
     def getDecisionDescription(self, recognizer:Parser, dfa:DFA):

--- a/src/antlr4/tree/ParseTreeMatch.py
+++ b/src/antlr4/tree/ParseTreeMatch.py
@@ -135,9 +135,9 @@ class ParseTreeMatch(object):
     #
     def __str__(self):
         with StringIO() as buf:
-            buf.write(u"Match ")
-            buf.write(u"succeeded" if self.succeeded() else "failed")
-            buf.write(u"; found ")
+            buf.write("Match ")
+            buf.write("succeeded" if self.succeeded() else "failed")
+            buf.write("; found ")
             buf.write(str(len(self.labels)))
-            buf.write(u" labels")
+            buf.write(" labels")
             return buf.getvalue()

--- a/src/antlr4/tree/ParseTreePatternMatcher.py
+++ b/src/antlr4/tree/ParseTreePatternMatcher.py
@@ -86,8 +86,9 @@
 # {@link #setDelimiters}. You must escape both start and stop strings
 # {@code \<} and {@code \>}.</p>
 #
-from antlr4 import Lexer, CommonTokenStream, ParserRuleContext
+from antlr4 import Lexer, CommonTokenStream
 from antlr4.InputStream import InputStream
+from antlr4.ParserRuleContext import ParserRuleContext
 from antlr4.ListTokenSource import ListTokenSource
 from antlr4.Token import Token
 from antlr4.error.ErrorStrategy import BailErrorStrategy

--- a/src/antlr4/tree/Trees.py
+++ b/src/antlr4/tree/Trees.py
@@ -52,14 +52,14 @@ class Trees(object):
         if t.getChildCount()==0:
             return s
         with StringIO() as buf:
-            buf.write(u"(")
+            buf.write("(")
             buf.write(s)
             buf.write(' ')
             for i in range(0, t.getChildCount()):
                 if i > 0:
                     buf.write(' ')
                 buf.write(cls.toStringTree(t.getChild(i), ruleNames))
-            buf.write(u")")
+            buf.write(")")
             return buf.getvalue()
 
     @classmethod

--- a/src/antlr4/xpath/XPath.py
+++ b/src/antlr4/xpath/XPath.py
@@ -99,12 +99,12 @@ class XPathLexer(Lexer):
     ID = 7
     STRING = 8
 
-    modeNames = [ u"DEFAULT_MODE" ]
+    modeNames = [ "DEFAULT_MODE" ]
 
-    literalNames = [ u"<INVALID>",
+    literalNames = [ "<INVALID>",
             "'//'", "'/'", "'*'", "'!'" ]
 
-    symbolicNames = [ u"<INVALID>",
+    symbolicNames = [ "<INVALID>",
             "TOKEN_REF", "RULE_REF", "ANYWHERE", "ROOT", "WILDCARD", "BANG",
             "ID", "STRING" ]
 


### PR DESCRIPTION
Allow to use the runtime library under Python versions as low as 3.2.

Signed-off-by: jcbrinfo <jcbrinfo@users.noreply.github.com>