### PR TITLE
Reintroduce `Interval`

### DIFF
--- a/src/antlr4/LL1Analyzer.py
+++ b/src/antlr4/LL1Analyzer.py
@@ -28,7 +28,7 @@
 #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 #  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #/
-from antlr4.IntervalSet import IntervalSet
+from antlr4.IntervalSet import IntervalSet, Interval
 from antlr4.Token import Token
 from antlr4.PredictionContext import PredictionContext, SingletonPredictionContext, PredictionContextFromRuleContext
 from antlr4.RuleContext import RuleContext
@@ -188,7 +188,7 @@ class LL1Analyzer (object):
             elif t.isEpsilon:
                 self._LOOK(t.target, stopState, ctx, look, lookBusy, calledRuleStack, seeThruPreds, addEOF)
             elif type(t) == WildcardTransition:
-                look.addRange( range(Token.MIN_USER_TOKEN_TYPE, self.atn.maxTokenType + 1) )
+                look.addRange( Interval(Token.MIN_USER_TOKEN_TYPE, self.atn.maxTokenType + 1) )
             else:
                 set_ = t.label
                 if set_ is not None:

--- a/src/antlr4/atn/ATNDeserializer.py
+++ b/src/antlr4/atn/ATNDeserializer.py
@@ -29,6 +29,7 @@
 #/
 from uuid import UUID
 from io import StringIO
+from antlr4.IntervalSet import Interval
 from antlr4.Token import Token
 from antlr4.atn.ATN import ATN
 from antlr4.atn.ATNType import ATNType
@@ -208,7 +209,7 @@ class ATNDeserializer (object):
             for j in range(0, n):
                 i1 = self.readInt()
                 i2 = self.readInt()
-                iset.addRange(range(i1, i2 + 1)) # range upper limit is exclusive
+                iset.addRange(Interval(i1, i2 + 1)) # range upper limit is exclusive
         return sets
 
     def readEdges(self, atn:ATN, sets:list):

--- a/src/antlr4/atn/Transition.py
+++ b/src/antlr4/atn/Transition.py
@@ -41,7 +41,7 @@
 #  the states. We'll use the term Edge for the DFA to distinguish them from
 #  ATN transitions.</p>
 #
-from antlr4.IntervalSet import IntervalSet
+from antlr4.IntervalSet import IntervalSet, Interval
 from antlr4.Token import Token
 
 # need forward declarations
@@ -148,7 +148,7 @@ class RangeTransition(Transition):
 
     def makeLabel(self):
         s = IntervalSet()
-        s.addRange(range(self.start, self.stop + 1))
+        s.addRange(Interval(self.start, self.stop + 1))
         return s
 
     def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int):
@@ -208,7 +208,7 @@ class SetTransition(Transition):
             self.label = set
         else:
             self.label = IntervalSet()
-            self.label.addRange(range(Token.INVALID_TYPE, Token.INVALID_TYPE + 1))
+            self.label.addRange(Interval(Token.INVALID_TYPE, Token.INVALID_TYPE + 1))
 
     def matches( self, symbol:int, minVocabSymbol:int,  maxVocabSymbol:int):
         return symbol in self.label


### PR DESCRIPTION
For Python 3.4 and higher, make an alias to `range`. For lower versions,
use the same definition as in the Python 2 runtime library.

Signed-off-by: jcbrinfo <jcbrinfo@users.noreply.github.com>