### PR TITLE
Fix syntax of the generated source code (again)

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -156,9 +156,9 @@ class <parser.name> ( <if(superClass)><superClass><else>Parser<endif> ):
 
     sharedContextCache = PredictionContextCache()
 
-    literalNames = [ <parser.literalNames:{t | u<t>}; null="u\"\<INVALID>\"", separator=", ", wrap, anchor> ]
+    literalNames = [ <parser.literalNames:{t | <t>}; null="\"\<INVALID>\"", separator=", ", wrap, anchor> ]
 
-    symbolicNames = [ <parser.symbolicNames:{t | u<t>}; null="u\"\<INVALID>\"", separator=", ", wrap, anchor> ]
+    symbolicNames = [ <parser.symbolicNames:{t | <t>}; null="\"\<INVALID>\"", separator=", ", wrap, anchor> ]
 
     <parser.rules:{r | RULE_<r.name> = <r.index>}; separator="\n", wrap, anchor>
 


### PR DESCRIPTION
Looked for less obvious cases.

Signed-off-by: jcbrinfo <jcbrinfo@users.noreply.github.com>