### PR TITLE
Do not rely on `__package__`

### DIFF
--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Python3/Python3.stg
@@ -54,9 +54,7 @@ ParserFile(file, parser, namedActions) ::= <<
 from antlr4 import *
 from io import StringIO
 <if(file.genListener || file.genVisitor)>
-package = globals().get("__package__", None)
-ischild = len(package)>0 if package is not None else False
-if ischild:
+if __name__ is not None and "." in __name__:
     <if(file.genListener)>
     from .<file.parser.grammarName>Listener import <file.parser.grammarName>Listener
     <endif>


### PR DESCRIPTION
This variable can be let to `None` even when the module is in a package.

Signed-off-by: jcbrinfo <jcbrinfo@users.noreply.github.com>